### PR TITLE
send email reminder for task deadline using APSchedular

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
+APScheduler==3.11.0
 asgiref==3.9.1
 Django==5.2.6
+django-crontab==0.7.1
 djangorestframework==3.16.1
 djangorestframework_simplejwt==5.5.1
 mysqlclient==2.2.7
@@ -8,3 +10,4 @@ python-decouple==3.8
 sqlparse==0.5.3
 typing_extensions==4.15.0
 tzdata==2025.2
+tzlocal==5.3.1

--- a/task_app/apps.py
+++ b/task_app/apps.py
@@ -7,3 +7,5 @@ class TaskAppConfig(AppConfig):
 
     def ready(self):
         import task_app.signals
+        from task_app.asp_cron import start_scheduler
+        start_scheduler()

--- a/task_app/asp_cron.py
+++ b/task_app/asp_cron.py
@@ -1,0 +1,38 @@
+from apscheduler.schedulers.background import BackgroundScheduler
+from django.utils import timezone
+from django.core.mail import send_mail
+from django.conf import settings
+from task_app.models import Task
+from django.conf import settings
+
+
+def send_deadline_reminders():
+    tommorow = timezone.now() + timezone.timedelta(days=1)
+    tasks = Task.objects.filter(due_date__date=tommorow)        # extracts just the date portion from the datetime field.
+
+    for task in tasks:
+        for user in task.users.all():
+            subject = f"Reminder : task  '{task.title}' is due"
+            message = f"""
+                        Hello {user.username},
+                        This is reminder that the task '{task.title}
+                        is due on {task.due_date.strftime('%Y-%m-%d %H:%M')},
+                        Please make sure to complete it on time.
+                        """
+            send_mail(
+                subject,
+                message,
+                settings.DEFAULT_FROM_EMAIL,
+                [user.email],
+                fail_silently=True
+            )
+        print("Reminder mail send to the user")
+
+
+def start_scheduler():
+    scheduler = BackgroundScheduler()
+    # runs every day at 9 AM
+    # scheduler.add_job(send_deadline_reminders, 'cron', hour=9)
+    # for testing purpose run evry minutes
+    scheduler.add_job(send_deadline_reminders, 'interval', minutes=1)
+    scheduler.start()

--- a/task_app/cron.py
+++ b/task_app/cron.py
@@ -1,0 +1,29 @@
+
+from django.utils import timezone
+from datetime import timedelta
+from django.core.mail import send_mail
+from task_app.models import Task
+from django.conf import settings
+
+
+def send_due_soon_reminders():
+    tommorow = timezone.now() + timedelta(days=1)
+    tasks = Task.objects.filter(due_date__date=tommorow)
+    
+    for task in tasks:
+        for user in task.users.all():
+            subject = f"Reminder : task  '{task.title}' is due"
+            message = f"""
+                        Hello {user.username},
+                        This is reminder that the task '{task.title}
+                        is due on {task.due_date.strftime('%Y-%m-%d %H:%M')},
+                        Please make sure to complete it on time.
+                        """
+            send_mail(
+                subject,
+                message,
+                settings.DEFAULT_FROM_EMAIL,
+                [user.email],
+                fail_silently=True
+            )
+        

--- a/task_app/management/commands/send_reminders.py
+++ b/task_app/management/commands/send_reminders.py
@@ -1,0 +1,36 @@
+from django.core.management import BaseCommand
+from django.utils import timezone
+from django.core.mail import send_mail
+from django.conf import settings
+from task_app.models import Task
+
+
+class Command(BaseCommand):
+
+    help = "Send email for deadline reminder for task"
+
+    def handle(self, *args, **options):
+        tommorow = timezone.now() + timezone.timedelta(days=1)
+        # extracts just the date portion from the datetime field.
+        tasks = Task.objects.filter(due_date__date=tommorow)
+
+        for task in tasks:
+            for user in task.users.all():
+                subject = f"Reminder : task  '{task.title}' is due"
+                message = f"""
+                            Hello {user.username},
+                            This is reminder that the task '{task.title}
+                            is due on {task.due_date.strftime('%Y-%m-%d %H:%M')},
+                            Please make sure to complete it on time.
+                            """
+                send_mail(
+                    subject,
+                    message,
+                    settings.DEFAULT_FROM_EMAIL,
+                    [user.email],
+                    fail_silently=True
+                )
+                self.stdout.write(self.style.SUCCESS(f"Reminder sent to {user.email} for task {task.title}"))
+
+        if not tasks.exists():
+            self.stdout.write(self.style.WARNING("No tasks due tomorrow"))

--- a/todo/settings.py
+++ b/todo/settings.py
@@ -41,9 +41,11 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    # External apps and libraries
     "rest_framework",
     "rest_framework_simplejwt",
     'rest_framework_simplejwt.token_blacklist',
+    # 'django_crontab',
     "user_app",
     'task_app',
 ]
@@ -171,3 +173,10 @@ EMAIL_USE_TLS = config("EMAIL_USE_TLS", cast=bool)
 EMAIL_HOST_USER = config("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD")
 DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL")
+
+
+# Register the cron tabs
+# CRONJOBS = [
+#     # Runs every day at 9 AM
+#     ('0 9 * * *', 'task_app.cron.send_due_soon_reminders'),
+# ]


### PR DESCRIPTION
- First added the cron-tab (but it not support by window) so use the APSchedular
- Added APSchedular for send email for reminder
- also added django-management command 
- so we can direcly run python manage.py send_reminder.py from terminal or script if we want
- not added the window task_manager setup.